### PR TITLE
Changed Urn to match Rust Urn crate

### DIFF
--- a/Development/nmos/registry_resources.cpp
+++ b/Development/nmos/registry_resources.cpp
@@ -30,7 +30,7 @@ namespace nmos
                         .set_scheme(nmos::http_scheme(settings))
                         .set_port(nmos::experimental::fields::mdns_port(settings))
                         .set_path(U("/x-dns-sd/") + make_api_version(version));
-                    auto type = U("urn:x-dns-sd/") + make_api_version(version);
+                    auto type = U("urn:x-dns-sd:mdns-advertisement");
 
                     for (const auto& host : hosts)
                     {


### PR DESCRIPTION
Not sure if the Rust crate is too pedantic or if the nmos-cpp urn is just wrong, but we couldn't parse the default node in the translator. pretty annoying.