### PR TITLE
Removed . from default domain

### DIFF
--- a/Development/nmos/settings.cpp
+++ b/Development/nmos/settings.cpp
@@ -22,7 +22,7 @@ namespace nmos
                 if (!interface.domain.empty())
                     return interface.domain;
             }
-            return U("local.");
+            return U("local");
         }
 
         // Get default (system) host name as an FQDN (fully qualified domain name)


### PR DESCRIPTION
### Context
Removed `.` from default domain. This is configurable, but changing the default makes it so we have to worry about one thing less.

### Reasoning
Nmos-cpp sends out hostname http-headers which reqwest / hyper parse as a `hostname`. the default domain `local.` is not a valid hostname since it ends with a `.`